### PR TITLE
the pointer returned by c_str only exists within the life of param

### DIFF
--- a/src/PqResult.h
+++ b/src/PqResult.h
@@ -91,9 +91,10 @@ public:
 
     std::vector<const char*> c_params(nparams_);
     std::vector<int> c_formats(nparams_);
+    std::vector<std::string> s_params(nparams_);
     for (int i = 0; i < nparams_; ++i) {
-      std::string param(params[i][0]);
-      c_params[i] = param.c_str();
+      s_params[i] = Rcpp::as<std::string>(params[i][0]);
+      c_params[i] = s_params[i].c_str();
       c_formats[i] = 0;
     }
 
@@ -116,6 +117,7 @@ public:
     int n = params[0].size();
 
     std::vector<const char*> c_params(nparams_);
+    std::vector<std::string> s_params(nparams_);
     std::vector<int> c_formats(nparams_);
     for (int j = 0; j < nparams_; ++j) {
       c_formats[j] = 0;
@@ -126,8 +128,8 @@ public:
         Rcpp::checkUserInterrupt();
 
       for (int j = 0; j < nparams_; ++j) {
-        std::string param(params[j][i]);
-        c_params[j] = param.c_str();
+        s_params[j] = Rcpp::as<std::string>(params[j][i]);
+        c_params[j] = s_params[j].c_str();
       }
 
       PGresult* res = PQexecPrepared(pConn_->conn(), "", nparams_,


### PR DESCRIPTION
Prepared statements didn't work. Currently:

```R
dbGetQuery(dbcon, "SELECT * FROM mytable WHERE var1=$1 and var2=$2", params=list("42", "18"))
```
will try to set both variables to 18.
I fixed it by copying params list into a `std::vector<std::string>`, so that the pointer doesn't get destroyed.
  