### PR TITLE
types_[i] can be equal to LGLSXP

### DIFF
--- a/src/PqResult.h
+++ b/src/PqResult.h
@@ -221,6 +221,7 @@ public:
       case INTSXP:  types[i] = "integer"; break;
       case REALSXP: types[i] = "double"; break;
       case VECSXP:  types[i] = "list"; break;
+      case LGLSXP:  types[i] = "logical"; break;
       default: Rcpp::stop("Unknown variable type");
       }
     }


### PR DESCRIPTION
The function columnTypes can return LGLSXP, but this wan't picked up by columninfo which would error out.