### PR TITLE
configure update for Amazon Linux

### DIFF
--- a/configure
+++ b/configure
@@ -18,6 +18,13 @@ if [ -r "/usr/include/postgresql/libpq-fe.h" ]; then
   exit 0;
 fi
 
+# Amazon Linux
+if [ -r "/usr/include/pgsql/libpq-fe.h" ]; then
+  echo "PKG_CPPFLAGS= -I/usr/include/pgsql" > src/Makevars
+  echo "PKG_LIBS=-lpq" >> src/Makevars
+  exit 0;
+fi
+
 # Force static linking on OSX to support redistributable binary packages.
 if [ $(echo "$OSTYPE" | grep "darwin") ]; then
 


### PR DESCRIPTION
Fixes the installation error of not being able locate `libpq-fe.h` for (at a minimum) Amazon Linux, which installs those header files (by default) at `/usr/include/pgsql`.
The patched version installs correctly now on Amazon Linux (4.1.7-15.23.amzn1.x86_64).
