### PR TITLE
Return 'jsonb' as strings

### DIFF
--- a/src/PqResult.h
+++ b/src/PqResult.h
@@ -272,6 +272,7 @@ private:
       case 19: // NAME
       case 25: // TEXT
       case 114: // JSON
+      case 3802: // JSONB
       case 1042: // CHAR
       case 1043: // VARCHAR
       case 1082: // DATE
@@ -289,7 +290,6 @@ private:
 
       case 17: // BYTEA
       case 2278: // NULL
-      case 3802: // JSONB
         types.push_back(VECSXP);
         break;
 


### PR DESCRIPTION
The distinction between `json` and `jsonb` types only matters internally to postgres to determine if the json data gets stored in the db as an actual string or as a queryable json object. In the end, both types are the same json data and both should turn into a string in R, not a raw vector. 