### PR TITLE
added pg_config support; factored CFLAGS and LIBS as separate steps.

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ PKG_LIBS_STATIC="-lpq -lssl -lcrypto -lldap"
 # pkg-config values (if available)
 if [ $(command -v pkg-config) ]; then
   PKGCONFIG_CFLAGS=$(pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME})
-  PKGCONFIG_LIBS=$(pkg-config --libs --silencer-errors ${PKG_CONFIG_NAME})
+  PKGCONFIG_LIBS=$(pkg-config --libs --silence-errors ${PKG_CONFIG_NAME})
 fi
 
 # pg_config vlaues (if available)

--- a/configure
+++ b/configure
@@ -1,36 +1,58 @@
 #!/bin/bash
-# Anticonf (tm) script by Jeroen Ooms (2016)
-# This script will query 'pkg-config' for the required cflags and ldflags.
-# If pkg-config is unavailable or does not find the library, try setting
-# INCLUDE_DIR and LIB_DIR manually via e.g:
-# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+# Anticonf (tm) script by Jeroen Ooms & Murat Tasan (2016)
+# This script will prefer cflags (specifically includefile dirs) and lib dirs
+# in the following order of precedence:
+#   (1) INCLUDE_DIR or LIB_DIR entered explicitly on the command line, e.g.
+#       R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+#   (2) Values found via 'pkg-config' for the libpq package.
+#   (3) Values found via 'pg_config' given a PostgreSQL installation.
 
 # Library settings
 PKG_CONFIG_NAME="libpq"
 PKG_DEB_NAME="libpq-dev"
 PKG_RPM_NAME="postgresql-devel"
+PKG_AMZ_RPM_NAMES="postgreql8-devel, psstgresql92-devel, postgresql93-devel, or postgresql94-devel"
 PKG_CSW_NAME="postgresql_dev"
 PKG_BREW_NAME="postgresql"
 PKG_TEST_HEADER="<libpq-fe.h>"
 PKG_LIBS="-lpq"
 PKG_LIBS_STATIC="-lpq -lssl -lcrypto -lldap"
 
-# Use pkg-config if available
+# pkg-config values (if available)
 if [ $(command -v pkg-config) ]; then
   PKGCONFIG_CFLAGS=$(pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME})
-  PKGCONFIG_LIBS=$(pkg-config --libs ${PKG_CONFIG_NAME})
+  PKGCONFIG_LIBS=$(pkg-config --libs --silencer-errors ${PKG_CONFIG_NAME})
 fi
 
-# Note that cflags may be empty in case of success
-if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
-  echo "Found INCLUDE_DIR and/or LIB_DIR!"
+# pg_config vlaues (if available)
+if [ $(command -v pg_config) ]; then
+  PGCONFIG_INCLUDEDIR=$(pg_config --includedir)
+  PGCONFIG_LIBDIR=$(pg_config --libdir)
+fi
+
+if [ "$INCLUDE_DIR" ]; then
+  echo "Found INCLUDE_DIR!"
   PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
-  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
-elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
-  echo "Found pkg-config cflags and libs!"
+elif [ "$PKGCONFIG_CFLAGS" ]; then
+  echo "Found pkg-config cflags!"
   PKG_CFLAGS=${PKGCONFIG_CFLAGS}
+elif [ "$PGCONFIG_INCLUDEDIR" ]; then
+  echo "Found pg_config includedir!"
+  PKG_CFLAGS="-I${PGCONFIG_INCLUDEDIR} $PKG_CFLAGS"
+fi
+
+if [ "$LIB_DIR" ]; then
+  echo "Found LIB_DIR!"
+  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
+elif [ "$PKGCONFIG_LIBS" ]; then
+  echo "Found pkg-config libs!"
   PKG_LIBS=${PKGCONFIG_LIBS}
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif [ "$PGCONFIG_LIBDIR" ]; then
+  echo "Found pg_config libdir!"
+  PKG_LIBS="-L${PGCONFIG_LIBDIR} $PKG_LIBS"
+fi
+
+if [ -z "$PKG_CFLAGS" ] && [ -z "$PKG_LIBS" ] && [[ "$OSTYPE" == "darwin"* ]]; then
   if [ $(command -v brew) ]; then
     BREWDIR=$(brew --prefix)
   else
@@ -64,11 +86,15 @@ if [ $R_CONFIG_ERROR ]; then
   echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"
   echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
   echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
+  echo " * rpm: $PKG_AMZ_RPM_NAMES (Amazon Linux)"
   echo " * csw: $PKG_CSW_NAME (Solaris)"
   echo " * brew: $PKG_BREW_NAME (OSX)"
-  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"
-  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
-  echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
+  echo "If $PKG_CONFIG_NAME is already installed, check that either:"
+  echo "(i)  'pkg-config' is in your PATH AND PKG_CONFIG_PATH contains"
+  echo "     a $PKG_CONFIG_NAME.pc file; or"
+  echo "(ii) 'pg_config' is in your PATH."
+  echo "If neither can detect $PGK_CONFIG_NAME, you can set INCLUDE_DIR"
+  echo "and LIB_DIR manually via:"
   echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
   echo "--------------------------------------------------------------------"
   exit 1;


### PR DESCRIPTION
The PostgreSQL installations on Amazon Linux have a variety of annoying issues.
1. They don't play nicely with pkg-config, specifically libpq doesn't have any useful .pc entries.
2. The installation location is non-standard.

But (fortunately!), pg_config does work just fine... so, the proposed changes in this pull request are:
1. Factor the PKG_CFLAGS and PKG_LIBS into two separate steps (i.e. set the values for each one separately, and check for the cascading conditions below separately for each).
2. Cascade priority as follows (from highest in the list to lowest):
- INCLUDEDIR or LIBDIR found on the command line; then
- values retrieved from pkg-config, if available; then
- values retrieved from pg_config.

This solves the problem of screwed-up pkg-config entries more generally for Linux distributions outside just Amazon Linux.
And for Amazon Linux in particular, this solves the annoying installation issues.
(I've also included a separate message for Amazon Linux users since there is no generic postgresql-devel package... instead you _must_ specify the version, e.g. postgresql94-devel.)

I'm open to suggestions for other ways to make pkg-config and pg_config play nicely together in the case where both might be installed on a single system, but the pkg-config entries be erroneous or missing (as is the case for most Amazon Linux users).

Closes #22.
