### PR TITLE
Handle string quoting and missing values in strings

### DIFF
--- a/R/quote.R
+++ b/R/quote.R
@@ -19,7 +19,10 @@ NULL
 #' @export
 #' @rdname quote
 setMethod("dbQuoteString", c("PqConnection", "character"), function(conn, x, ...) {
-  SQL(connection_escape_string(conn@ptr, x))
+  is_na <- is.na(x)
+  res <- SQL(connection_escape_string(conn@ptr, x))
+  res[is_na] <- SQL("NULL")
+  res
 })
 
 #' @export

--- a/R/tables.R
+++ b/R/tables.R
@@ -95,6 +95,9 @@ setMethod("sqlData", "PqConnection", function(con, value, row.names = NA, copy =
   is_object <- vapply(value, is.object, logical(1))
   value[is_object] <- lapply(value[is_object], as.character)
 
+  is_character <- vapply(value, is.character, logical(1))
+  value[is_character] <- lapply(value[is_character], dbQuoteString, con = con)
+
   value
 })
 


### PR DESCRIPTION
I ran into this when trying to use `dbWriteTable(copy = FALSE)`. While the column and row names were escaped, the data values were not and `connection_escape_string` did not handle missing values.

Behavior after this PR

``` r
con <- dbConnect(RPostgres::Postgres(), db = "test_db", host = "localhost", password = "password", port = "5432")
dbQuoteString(con, c("AS", NA))
#> <SQL> 'AS'
#> <SQL> NULL
```

Missing values in non-character atomic vectors are still an issue, they don't seem to be handled currently.
